### PR TITLE
[WIP] pathoc: HTTP/2

### DIFF
--- a/libpathod/cmdline.py
+++ b/libpathod/cmdline.py
@@ -66,6 +66,17 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
         help="Connection timeout"
     )
     parser.add_argument(
+        "--http2", dest="use_http2", action="store_true", default=False,
+        help='Perform all requests over a single HTTP/2 connection.'
+    )
+    parser.add_argument(
+        "--http2-skip-connection-preface",
+        dest="http2_skip_connection_preface",
+        action="store_true",
+        default=False,
+        help='Skips the HTTP/2 connection preface before sending requests.')
+
+    parser.add_argument(
         'host', type=str,
         metavar = "host[:port]",
         help='Host and port to connect to'
@@ -77,6 +88,7 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
         specifcations
         """
     )
+
     group = parser.add_argument_group(
         'SSL',
     )
@@ -189,7 +201,7 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
             data = open(r).read()
             r = data
         try:
-            reqs.append(language.parse_pathoc(r))
+            reqs.append(language.parse_pathoc(r, args.use_http2))
         except language.ParseException as v:
             print >> stderr, "Error parsing request spec: %s" % v.msg
             print >> stderr, v.marked()

--- a/libpathod/language/base.py
+++ b/libpathod/language/base.py
@@ -15,13 +15,15 @@ class Settings:
         staticdir = None,
         unconstrained_file_access = False,
         request_host = None,
-        websocket_key = None
+        websocket_key = None,
+        protocol = None,
     ):
+        self.is_client = is_client
         self.staticdir = staticdir
         self.unconstrained_file_access = unconstrained_file_access
         self.request_host = request_host
-        self.websocket_key = websocket_key
-        self.is_client = is_client
+        self.websocket_key = websocket_key  # TODO: refactor this into the protocol
+        self.protocol = protocol
 
 
 Sep = pp.Optional(pp.Literal(":")).suppress()

--- a/libpathod/language/http2.py
+++ b/libpathod/language/http2.py
@@ -1,0 +1,119 @@
+import os
+import netlib.http2
+import pyparsing as pp
+from . import base, generators, actions, message
+
+"""
+    Normal HTTP requests:
+        <method>:<path>:<header>:<body>
+    e.g.:
+        GET:/
+        GET:/:foo=bar
+        POST:/:foo=bar:'content body payload'
+
+    Individual HTTP/2 frames:
+        h2f:<payload_length>:<type>:<flags>:<stream_id>:<payload>
+    e.g.:
+        h2f:0:PING
+        h2f:42:HEADERS:END_HEADERS:0x1234567:foo=bar,host=example.com
+        h2f:42:DATA:END_STREAM,PADDED:0x1234567:'content body payload'
+"""
+
+
+class Method(base.OptionsOrValue):
+    options = [
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+        "DELETE",
+    ]
+
+
+class Path(base.Value):
+    pass
+
+
+class Header(base.KeyValue):
+    preamble = "h"
+
+
+class Body(base.Value):
+    preamble = "b"
+
+
+class Times(base.Integer):
+    preamble = "x"
+
+
+class Request(message.Message):
+    comps = (
+        Header,
+        Body,
+
+        Times,
+    )
+
+    @property
+    def method(self):
+        return self.tok(Method)
+
+    @property
+    def path(self):
+        return self.tok(Path)
+
+    @property
+    def headers(self):
+        return self.toks(Header)
+
+    @property
+    def body(self):
+        return self.tok(Body)
+
+    @property
+    def times(self):
+        return self.tok(Times)
+
+    @property
+    def actions(self):
+        return []
+
+    @classmethod
+    def expr(klass):
+        parts = [i.expr() for i in klass.comps]
+        atom = pp.MatchFirst(parts)
+        resp = pp.And(
+            [
+                Method.expr(),
+                base.Sep,
+                Path.expr(),
+                base.Sep,
+                pp.ZeroOrMore(base.Sep + atom)
+            ]
+        )
+        resp = resp.setParseAction(klass)
+        return resp
+
+    def resolve(self, settings, msg=None):
+        tokens = self.tokens[:]
+        return self.__class__(
+            [i.resolve(settings, self) for i in tokens]
+        )
+
+    def values(self, settings):
+        return settings.protocol.create_request(
+            self.method.value.get_generator(settings),
+            self.path,
+            self.headers,
+            self.body)
+
+    def spec(self):
+        return ":".join([i.spec() for i in self.tokens])
+
+
+# class H2F(base.CaselessLiteral):
+#     TOK = "h2f"
+#
+#
+# class WebsocketFrame(message.Message):
+#     pass

--- a/libpathod/pathoc.py
+++ b/libpathod/pathoc.py
@@ -150,6 +150,10 @@ class Pathoc(tcp.TCPClient):
             clientcert=None,
             ciphers=None,
 
+            # HTTP/2
+            use_http2=False,
+            http2_skip_connection_preface=False,
+
             # Websockets
             ws_read_limit = None,
 
@@ -188,6 +192,9 @@ class Pathoc(tcp.TCPClient):
         self.sslversion = utils.SSLVERSIONS[sslversion]
         self.ciphers = ciphers
         self.sslinfo = None
+
+        self.use_http2 = use_http2
+        self.http2_skip_connection_preface = http2_skip_connection_preface
 
         self.ws_read_limit = ws_read_limit
 
@@ -407,6 +414,8 @@ def main(args):  # pragma: nocover
                 sslversion = args.sslversion,
                 clientcert = args.clientcert,
                 ciphers = args.ciphers,
+                use_http2 = args.use_http2,
+                http2_skip_connection_preface = args.http2_skip_connection_preface,
                 showreq = args.showreq,
                 showresp = args.showresp,
                 explain = args.explain,


### PR DESCRIPTION
This PR adds support for basic HTTP/2 requests in pathoc.
Example:
```bash
./pathoc 127.0.0.1:443 'GET:/index.html' 'GET:other.html' -e -q -p -x -s --http2
```
```
08-06-15 10:54:56: >> 'GET':/index.html
<< 200 : 22 bytes
Bytes written:
        0000000000 00 00 03 01 05 00 00 00 01 82 85 87             ............
Bytes read:
        0000000000 00 00 55 01 04 00 00 00 01 88 76 8b 9c 47 60 2b ..U.......v..G`+
        0000000010 89 70 ac 3a 2b 9c 61 61 97 d0 7a be 94 03 ca 65 .p.:+.aa..z....e
        0000000020 b6 a5 04 00 b6 a0 1e b8 db 57 1b 71 4c 5a 37 ff .........W.qLZ7.
        0000000030 5f 87 49 7c a5 89 d3 4d 1f 6c 96 df 69 7e 94 13 _.I|...M.l..i~..
        0000000040 8a 68 1f a5 04 00 b6 a0 83 71 a6 ae 34 e2 98 b4 .h.......q..4...
        0000000050 6f 62 8b fe 5b 6d c6 8a fb 45 58 2e 7f 3f 00 00 ob..[m...EX..?..
        0000000060 16 00 01 00 00 00 01 69 6e 64 65 78 20 66 69 6c .......index fil
        0000000070 65 20 2d 20 69 74 20 77 6f 72 6b 73 0a          e - it works.
08-06-15 10:54:56: >> 'GET':other.html
<< 200 : 15 bytes
Bytes written:
        0000000000 00 00 0b 01 05 00 00 00 03 82 44 87 3a 67 2d 8b ..........D.:g-.
        0000000010 ce 9a 68 87                                     ..h.
Bytes read:
        0000000000 00 00 28 01 04 00 00 00 03 88 c2 c1 c0 6c 96 d0 ..(..........l..
        0000000010 7a be 94 00 54 cb 6d 4a 08 01 6d 40 b3 70 0d dc z...T.mJ..m@.p..
        0000000020 6d b5 31 68 df 62 8a fe 5b 6d c2 36 f4 6c ad 2f m.1h.b..[m.6.l./
        0000000030 f3 00 00 0f 00 01 00 00 00 03 64 69 66 66 65 72 ..........differ
        0000000040 65 6e 74 20 66 69 6c 65 0a                      ent file.
```

* new CLI argument to select the HTTP/2 protocol (default: False, i.e. HTTP1.1 is used)
* new CLI argument to skip the HTTP/2 connection preface (default: False, i.e. preface is performed)
    * (hidden from regular output, i.e. not printed in "Bytes written" or "Bytes received" sections
* ALPN support for pathoc connections
   * defaults to `http1.1`, unless HTTP/2 is enabled
* new language which defines a basic HTTP/2 request. 
    * this is going to be expanded in the future to get as close as possible to the HTTP1.1 language (some features might not be possible)
    * support for raw HTTP/2 frames in the language will also be part of a future PR
* preliminary support for on-the-wire protocols
    * HTTP/2 is already a protocol (imported from netlib)
    * websockets and HTTP1.1 should be refactored in order to cleanup pathoc.py from all these protocol-related methods and state.


WIP: add tests for new functionality and arguments