### PR TITLE
unify SSL version/method handling

### DIFF
--- a/libpathod/pathoc.py
+++ b/libpathod/pathoc.py
@@ -154,7 +154,7 @@ class Pathoc(tcp.TCPClient):
             # SSL
             ssl=None,
             sni=None,
-            sslversion='SSLv23',
+            ssl_version=tcp.SSL_DEFAULT_METHOD,
             clientcert=None,
             ciphers=None,
 
@@ -193,7 +193,7 @@ class Pathoc(tcp.TCPClient):
 
         self.ssl, self.sni = ssl, sni
         self.clientcert = clientcert
-        self.sslversion = utils.SSLVERSIONS[sslversion]
+        self.ssl_version = ssl_version
         self.ciphers = ciphers
         self.sslinfo = None
 
@@ -280,7 +280,7 @@ class Pathoc(tcp.TCPClient):
                 self.convert_to_ssl(
                     sni=self.sni,
                     cert=self.clientcert,
-                    method=self.sslversion,
+                    method=self.ssl_version,
                     cipher_list=self.ciphers,
                     alpn_protos=alpn_protos
                 )
@@ -461,7 +461,7 @@ def main(args):  # pragma: nocover
                 (args.host, args.port),
                 ssl=args.ssl,
                 sni=args.sni,
-                sslversion=args.sslversion,
+                ssl_version=args.ssl_version,
                 clientcert=args.clientcert,
                 ciphers=args.ciphers,
                 use_http2=args.use_http2,

--- a/libpathod/pathoc_cmdline.py
+++ b/libpathod/pathoc_cmdline.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
 import sys
 import argparse
 import os
 import os.path
-from netlib import http_uastrings
+
+from netlib import http_uastrings, tcp
 from . import pathoc, version, utils, language
 
 
@@ -108,10 +108,11 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
         help="SSL cipher specification"
     )
     group.add_argument(
-        "--sslversion", dest="sslversion", type=str, default='SSLv23',
-        choices=utils.SSLVERSIONS.keys(),
+        "--ssl-version", dest="ssl_version", type=str, default=tcp.SSL_DEFAULT_VERSION,
+        choices=tcp.SSL_VERSIONS.keys(),
         help=""""
-            Use a specified protocol - TLSv1.2, TLSv1.1, TLSv1, SSLv3, SSLv2, SSLv23.
+            Use a specified protocol:
+            TLSv1.2, TLSv1.1, TLSv1, SSLv3, SSLv2, SSLv23.
             Default to SSLv23."""
     )
 
@@ -160,6 +161,8 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
     )
 
     args = parser.parse_args(argv[1:])
+
+    args.ssl_version = tcp.SSL_VERSIONS[args.ssl_version]
 
     args.port = None
     if ":" in args.host:
@@ -215,6 +218,7 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
             print >> stderr, v.marked()
             sys.exit(1)
     args.requests = reqs
+
     return args
 
 

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -37,7 +37,7 @@ class SSLOptions(object):
         sans=(),
         not_after_connect=None,
         request_client_cert=False,
-        sslversion=tcp.SSLv23_METHOD,
+        ssl_version=tcp.SSL_DEFAULT_METHOD,
         ciphers=None,
         certs=None,
         alpn_select=http2.HTTP2Protocol.ALPN_PROTO_H2,
@@ -47,7 +47,7 @@ class SSLOptions(object):
         self.sans = sans
         self.not_after_connect = not_after_connect
         self.request_client_cert = request_client_cert
-        self.sslversion = sslversion
+        self.ssl_version = ssl_version
         self.ciphers = ciphers
         self.alpn_select = alpn_select
         self.certstore = certutils.CertStore.from_store(
@@ -181,7 +181,7 @@ class PathodHandler(tcp.BaseHandler):
                     handle_sni=self._handle_sni,
                     request_client_cert=self.server.ssloptions.request_client_cert,
                     cipher_list=self.server.ssloptions.ciphers,
-                    method=self.server.ssloptions.sslversion,
+                    method=self.server.ssloptions.ssl_version,
                     alpn_select=self.server.ssloptions.alpn_select,
                 )
             except tcp.NetLibError as v:
@@ -403,7 +403,7 @@ class PathodHandler(tcp.BaseHandler):
                     handle_sni=self._handle_sni,
                     request_client_cert=self.server.ssloptions.request_client_cert,
                     cipher_list=self.server.ssloptions.ciphers,
-                    method=self.server.ssloptions.sslversion,
+                    method=self.server.ssloptions.ssl_version,
                     alpn_select=self.server.ssloptions.alpn_select,
                 )
             except tcp.NetLibError as v:
@@ -592,7 +592,7 @@ def main(args):  # pragma: nocover
         confdir=args.confdir,
         not_after_connect=args.ssl_not_after_connect,
         ciphers=args.ciphers,
-        sslversion=utils.SSLVERSIONS[args.sslversion],
+        ssl_version=args.ssl_version,
         certs=args.ssl_certs,
         sans=args.sans,
     )

--- a/libpathod/pathod_cmdline.py
+++ b/libpathod/pathod_cmdline.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
 import sys
 import argparse
 import os
 import os.path
 import re
+
+from netlib import tcp
 from . import pathod, version, utils
 
 
@@ -138,10 +139,11 @@ def args_pathod(argv, stdout_=sys.stdout, stderr_=sys.stderr):
         """
     )
     group.add_argument(
-        "--sslversion", dest="sslversion", type=str, default='SSLv23',
-        choices=utils.SSLVERSIONS.keys(),
+        "--ssl-version", dest="ssl_version", type=str, default=tcp.SSL_DEFAULT_VERSION,
+        choices=tcp.SSL_VERSIONS.keys(),
         help=""""
-            Use a specified protocol - TLSv1.2, TLSv1.1, TLSv1, SSLv3, SSLv2, SSLv23.
+            Use a specified protocol:
+            TLSv1.2, TLSv1.1, TLSv1, SSLv3, SSLv2, SSLv23.
             Default to SSLv23."""
     )
 
@@ -179,6 +181,8 @@ def args_pathod(argv, stdout_=sys.stdout, stderr_=sys.stderr):
 
 
     args = parser.parse_args(argv[1:])
+
+    args.ssl_version = tcp.SSL_VERSIONS[args.ssl_version]
 
     certs = []
     for i in args.ssl_certs:
@@ -220,6 +224,7 @@ def args_pathod(argv, stdout_=sys.stdout, stderr_=sys.stderr):
             return parser.error("Invalid regex in anchor: %s" % patt)
         anchors.append((arex, spec))
     args.anchors = anchors
+
     return args
 
 

--- a/libpathod/utils.py
+++ b/libpathod/utils.py
@@ -2,14 +2,6 @@ import os
 import sys
 from netlib import tcp
 
-SSLVERSIONS = {
-    'TLSv1.2': tcp.TLSv1_2_METHOD,
-    'TLSv1.1': tcp.TLSv1_1_METHOD,
-    'TLSv1': tcp.TLSv1_METHOD,
-    'SSLv3': tcp.SSLv3_METHOD,
-    'SSLv2': tcp.SSLv2_METHOD,
-    'SSLv23': tcp.SSLv23_METHOD,
-}
 
 SIZE_UNITS = dict(
     b=1024 ** 0,


### PR DESCRIPTION
based on @mhils comment: https://github.com/mitmproxy/pathod/pull/27/files#r32608761
This PR unifies the usage of SSL version and method identifiers from CLI and internal usage.

Requires these other PRs to work: https://github.com/mitmproxy/netlib/pull/75