### PR TITLE
HTTP protocol refactoring

### DIFF
--- a/examples/test_context.py
+++ b/examples/test_context.py
@@ -16,7 +16,7 @@ def test_simple():
 
         # Check the returned data
         assert r.status_code == 200
-        assert len(r.content) == 100
+        assert len(r.body) == 100
 
         # Check pathod's internal log
         log = d.last_log()["request"]

--- a/examples/test_setup.py
+++ b/examples/test_setup.py
@@ -24,7 +24,7 @@ class Test:
 
         # Check the returned data
         assert r.status_code == 200
-        assert len(r.content) == 100
+        assert len(r.body) == 100
 
         # Check pathod's internal log
         log = self.d.last_log()["request"]

--- a/examples/test_setupall.py
+++ b/examples/test_setupall.py
@@ -29,7 +29,7 @@ class Test:
 
         # Check the returned data
         assert r.status_code == 200
-        assert len(r.content) == 100
+        assert len(r.body) == 100
 
         # Check pathod's internal log
         log = self.d.last_log()["request"]

--- a/libpathod/app.py
+++ b/libpathod/app.py
@@ -4,7 +4,7 @@ import cStringIO
 import copy
 from flask import Flask, jsonify, render_template, request, abort, make_response
 from . import version, language, utils
-from netlib import http_uastrings
+from netlib.http import user_agents
 
 logging.basicConfig(level="DEBUG")
 EXAMPLE_HOST = "example.com"
@@ -76,7 +76,7 @@ def make_app(noapi, debug):
     def docs_language():
         return render(
             "docs_lang.html", True,
-            section="docs", uastrings=http_uastrings.UASTRINGS,
+            section="docs", uastrings=user_agents.UASTRINGS,
             subsection="lang"
         )
 

--- a/libpathod/language/http.py
+++ b/libpathod/language/http.py
@@ -4,7 +4,7 @@ import abc
 import pyparsing as pp
 
 import netlib.websockets
-from netlib import http_status, http_uastrings
+from netlib.http import status_codes, user_agents
 from . import base, exceptions, actions, message
 
 
@@ -78,13 +78,13 @@ class ShortcutLocation(_HeaderMixin, base.Value):
 
 class ShortcutUserAgent(_HeaderMixin, base.OptionsOrValue):
     preamble = "u"
-    options = [i[1] for i in http_uastrings.UASTRINGS]
+    options = [i[1] for i in user_agents.UASTRINGS]
     key = base.TokValueLiteral("User-Agent")
 
     def values(self, settings):
         value = self.value.val
         if self.option_used:
-            value = http_uastrings.get_by_shortcut(value.lower())[2]
+            value = user_agents.get_by_shortcut(value.lower())[2]
 
         return self.format_header(
             self.key.get_generator(settings),
@@ -175,7 +175,7 @@ class Response(_HTTPMessage):
             l.extend(self.reason.values(settings))
         else:
             l.append(
-                http_status.RESPONSES.get(
+                status_codes.RESPONSES.get(
                     code,
                     "Unknown code"
                 )

--- a/libpathod/language/http.py
+++ b/libpathod/language/http.py
@@ -194,7 +194,7 @@ class Response(_HTTPMessage):
                     1,
                     Code(101)
                 )
-            hdrs = netlib.websockets.server_handshake_headers(
+            hdrs = netlib.websockets.WebsocketsProtocol.server_handshake_headers(
                 settings.websocket_key
             )
             for i in hdrs.lst:
@@ -306,7 +306,7 @@ class Request(_HTTPMessage):
                     1,
                     Method("get")
                 )
-            for i in netlib.websockets.client_handshake_headers().lst:
+            for i in netlib.websockets.WebsocketsProtocol.client_handshake_headers().lst:
                 if not get_header(i[0], self.headers):
                     tokens.append(
                         Header(

--- a/libpathod/language/http2.py
+++ b/libpathod/language/http2.py
@@ -1,6 +1,6 @@
 import pyparsing as pp
 
-from netlib import http_status, http_uastrings
+from netlib.http import user_agents
 from . import base, message
 
 """
@@ -116,13 +116,13 @@ class ShortcutLocation(_HeaderMixin, base.Value):
 
 class ShortcutUserAgent(_HeaderMixin, base.OptionsOrValue):
     preamble = "u"
-    options = [i[1] for i in http_uastrings.UASTRINGS]
+    options = [i[1] for i in user_agents.UASTRINGS]
     key = base.TokValueLiteral("user-agent")
 
     def values(self, settings):
         value = self.value.val
         if self.option_used:
-            value = http_uastrings.get_by_shortcut(value.lower())[2]
+            value = user_agents.get_by_shortcut(value.lower())[2]
 
         return (
             self.key.get_generator(settings),

--- a/libpathod/pathoc.py
+++ b/libpathod/pathoc.py
@@ -228,12 +228,12 @@ class Pathoc(tcp.TCPClient):
         l = self.rfile.readline()
         if not l:
             raise PathocError("Proxy CONNECT failed")
-        parsed = http.http1.parse_response_line(l)
+        parsed = self.protocol.parse_response_line(l)
         if not parsed[1] == 200:
             raise PathocError(
                 "Proxy CONNECT failed: %s - %s" % (parsed[1], parsed[2])
             )
-        http.http1.read_headers(self.rfile)
+        self.protocol.read_headers()
 
     def socks_connect(self, connect_to):
         try:

--- a/libpathod/pathoc.py
+++ b/libpathod/pathoc.py
@@ -417,7 +417,7 @@ class Pathoc(tcp.TCPClient):
             finally:
                 if resp:
                     lg("<< %s %s: %s bytes" % (
-                        resp.status_code, utils.xrepr(resp.msg), len(resp.content)
+                        resp.status_code, utils.xrepr(resp.msg), len(resp.body)
                     ))
                     if resp.status_code in self.ignorecodes:
                         lg.suppress()

--- a/libpathod/pathoc.py
+++ b/libpathod/pathoc.py
@@ -314,11 +314,6 @@ class Pathoc(tcp.TCPClient):
         if self.timeout:
             self.settimeout(self.timeout)
 
-    def _resp_summary(self, resp):
-        return "<< %s %s: %s bytes" % (
-            resp.status_code, utils.xrepr(resp.msg), len(resp.content)
-        )
-
     def stop(self):
         if self.ws_framereader:
             self.ws_framereader.terminate.put(None)
@@ -421,7 +416,9 @@ class Pathoc(tcp.TCPClient):
                 raise
             finally:
                 if resp:
-                    lg(self._resp_summary(resp))
+                    lg("<< %s %s: %s bytes" % (
+                        resp.status_code, utils.xrepr(resp.msg), len(resp.content)
+                    ))
                     if resp.status_code in self.ignorecodes:
                         lg.suppress()
             return resp

--- a/libpathod/pathoc_cmdline.py
+++ b/libpathod/pathoc_cmdline.py
@@ -3,7 +3,8 @@ import argparse
 import os
 import os.path
 
-from netlib import http_uastrings, tcp
+from netlib import tcp
+from netlib.http import user_agents
 from . import pathoc, version, language
 
 
@@ -16,7 +17,7 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
     pa = preparser.parse_known_args(argv)[0]
     if pa.showua:
         print >> stdout, "User agent strings:"
-        for i in http_uastrings.UASTRINGS:
+        for i in user_agents.UASTRINGS:
             print >> stdout, "  ", i[1], i[0]
         sys.exit(0)
 

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -212,7 +212,7 @@ class PathodHandler(tcp.BaseHandler):
                 spec = anchor_gen.next()
 
                 if self.use_http2 and isinstance(spec, language.http2.Response):
-                    spec.stream_id = stream_id
+                    spec.stream_id = req.stream_id
 
                 lg("crafting spec: %s" % spec)
                 nexthandler, retlog["response"] = self.http_serve_crafted(

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -133,7 +133,6 @@ class PathodHandler(tcp.BaseHandler):
                 return None, None
 
             if isinstance(req, http.ConnectRequest):
-                print([req.host, req.port, req.path])
                 return self.protocol.handle_http_connect([req.host, req.port, req.path], lg)
 
             method = req.method

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -6,7 +6,8 @@ import threading
 import urllib
 import time
 
-from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from netlib import tcp, http, wsgi, certutils, websockets, odict
+from netlib.http import http1, http2
 
 from . import version, app, language, utils, log, protocols
 import language.http

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -85,7 +85,7 @@ class PathodHandler(tcp.BaseHandler):
         self.use_http2 = False
         self.http2_framedump = http2_framedump
 
-    def _handle_sni(self, connection):
+    def handle_sni(self, connection):
         self.sni = connection.get_servername()
 
     def http_serve_crafted(self, crafted, logctx):
@@ -132,8 +132,8 @@ class PathodHandler(tcp.BaseHandler):
             if isinstance(req, http.EmptyRequest):
                 return None, None
 
-            if isinstance(req, http.ConnectRequest):
-                return self.protocol.handle_http_connect([req.host, req.port, req.path], lg)
+            if req.method == 'CONNECT':
+                return self.protocol.handle_http_connect([req.host, req.port, req.httpversion], lg)
 
             method = req.method
             path = req.path
@@ -239,7 +239,7 @@ class PathodHandler(tcp.BaseHandler):
                 self.convert_to_ssl(
                     cert,
                     key,
-                    handle_sni=self._handle_sni,
+                    handle_sni=self.handle_sni,
                     request_client_cert=self.server.ssloptions.request_client_cert,
                     cipher_list=self.server.ssloptions.ciphers,
                     method=self.server.ssloptions.ssl_version,

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -123,11 +123,12 @@ class PathodHandler(tcp.BaseHandler):
         """
         with logger.ctx() as lg:
             if self.use_http2:
-                stream_id, headers, body = self.protocol.read_request()
-                method = headers[':method']
-                path = headers[':path']
-                headers = odict.ODict(headers)
-                httpversion = ""
+                req = self.protocol.read_request()
+                method = req.method
+                path = req.path
+                headers = odict.ODictCaseless(req.headers)
+                httpversion = req.httpversion
+                stream_id = req.stream_id
             else:
                 req = self.protocol.read_request(lg)
                 if 'next_handle' in req:

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -280,7 +280,7 @@ class PathodHandler(tcp.BaseHandler):
                 retlog["cipher"] = self.get_current_cipher()
 
             m = utils.MemBool()
-            websocket_key = websockets.check_client_handshake(headers)
+            websocket_key = websockets.WebsocketsProtocol.check_client_handshake(headers)
             self.settings.websocket_key = websocket_key
 
             # If this is a websocket initiation, we respond with a proper

--- a/libpathod/pathod.py
+++ b/libpathod/pathod.py
@@ -138,7 +138,7 @@ class PathodHandler(tcp.BaseHandler):
             method = req.method
             path = req.path
             httpversion = req.httpversion
-            headers = odict.ODictCaseless(req.headers)
+            headers = req.headers
             body = req.body
 
             clientcert = None

--- a/libpathod/protocols/__init__.py
+++ b/libpathod/protocols/__init__.py
@@ -1,0 +1,1 @@
+from . import http, http2, websockets

--- a/libpathod/protocols/http.py
+++ b/libpathod/protocols/http.py
@@ -13,7 +13,7 @@ class HTTPProtocol:
     def make_error_response(self, reason, body):
         return language.http.make_error_response(reason, body)
 
-    def handle_http_app(self, method, path, headers, content, lg):
+    def handle_http_app(self, method, path, headers, body, lg):
         """
             Handle a request to the built-in app.
         """
@@ -25,7 +25,7 @@ class HTTPProtocol:
                 msg="Access denied: web interface disabled"
             )
         lg("app: %s %s" % (method, path))
-        req = wsgi.Request("http", method, path, headers, content)
+        req = wsgi.Request("http", method, path, headers, body)
         flow = wsgi.Flow(self.pathod_handler.address, req)
         sn = self.pathod_handler.connection.getsockname()
         a = wsgi.WSGIAdaptor(

--- a/libpathod/protocols/http.py
+++ b/libpathod/protocols/http.py
@@ -1,0 +1,110 @@
+from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from .. import version, app, language, utils, log
+
+class HTTPProtocol:
+
+    def __init__(self, pathod_handler):
+        self.pathod_handler = pathod_handler
+
+    def make_error_response(self, reason, body):
+        return language.http.make_error_response(reason, body)
+
+    def handle_http_app(self, method, path, headers, content, lg):
+        """
+            Handle a request to the built-in app.
+        """
+        if self.pathod_handler.server.noweb:
+            crafted = self.pathod_handler.make_http_error_response("Access Denied")
+            language.serve(crafted, self.pathod_handler.wfile, self.pathod_handler.settings)
+            return None, dict(
+                type="error",
+                msg="Access denied: web interface disabled"
+            )
+        lg("app: %s %s" % (method, path))
+        req = wsgi.Request("http", method, path, headers, content)
+        flow = wsgi.Flow(self.pathod_handler.address, req)
+        sn = self.pathod_handler.connection.getsockname()
+        a = wsgi.WSGIAdaptor(
+            self.pathod_handler.server.app,
+            sn[0],
+            self.pathod_handler.server.address.port,
+            version.NAMEVERSION
+        )
+        a.serve(flow, self.pathod_handler.wfile)
+        return self.pathod_handler.handle_http_request, None
+
+    def handle_http_connect(self, connect, lg):
+        """
+            Handle a CONNECT request.
+        """
+        http.read_headers(self.pathod_handler.rfile)
+        self.pathod_handler.wfile.write(
+            'HTTP/1.1 200 Connection established\r\n' +
+            ('Proxy-agent: %s\r\n' % version.NAMEVERSION) +
+            '\r\n'
+        )
+        self.pathod_handler.wfile.flush()
+        if not self.pathod_handler.server.ssloptions.not_after_connect:
+            try:
+                cert, key, chain_file_ = self.pathod_handler.server.ssloptions.get_cert(
+                    connect[0]
+                )
+                self.pathod_handler.convert_to_ssl(
+                    cert,
+                    key,
+                    handle_sni=self.pathod_handler._handle_sni,
+                    request_client_cert=self.pathod_handler.server.ssloptions.request_client_cert,
+                    cipher_list=self.pathod_handler.server.ssloptions.ciphers,
+                    method=self.pathod_handler.server.ssloptions.ssl_version,
+                    alpn_select=self.pathod_handler.server.ssloptions.alpn_select,
+                )
+            except tcp.NetLibError as v:
+                s = str(v)
+                lg(s)
+                return None, dict(type="error", msg=s)
+        return self.pathod_handler.handle_http_request, None
+
+    def read_request(self, lg):
+        line = http.get_request_line(self.pathod_handler.rfile)
+        if not line:
+            # Normal termination
+            return dict()
+
+        m = utils.MemBool()
+        if m(http.parse_init_connect(line)):
+            return dict(next_handle=self.handle_http_connect(m.v, lg))
+        elif m(http.parse_init_proxy(line)):
+            method, _, _, _, path, httpversion = m.v
+        elif m(http.parse_init_http(line)):
+            method, path, httpversion = m.v
+        else:
+            s = "Invalid first line: %s" % repr(line)
+            lg(s)
+            return dict(errors=dict(type="error", msg=s))
+
+        headers = http.read_headers(self.pathod_handler.rfile)
+        if headers is None:
+            s = "Invalid headers"
+            lg(s)
+            return dict(errors=dict(type="error", msg=s))
+
+        try:
+            body = http.read_http_body(
+                self.pathod_handler.rfile,
+                headers,
+                None,
+                method,
+                None,
+                True,
+            )
+        except http.HttpError as s:
+            s = str(s)
+            lg(s)
+            return dict(errors=dict(type="error", msg=s))
+
+        return dict(
+            method=method,
+            path=path,
+            headers=headers,
+            body=body,
+            httpversion=httpversion)

--- a/libpathod/protocols/http.py
+++ b/libpathod/protocols/http.py
@@ -68,46 +68,5 @@ class HTTPProtocol:
                 return None, dict(type="error", msg=s)
         return self.pathod_handler.handle_http_request, None
 
-    def read_request(self, lg):
-        line = self.wire_protocol.get_request_line()
-        if not line:
-            # Normal termination
-            return dict()
-
-        m = utils.MemBool()
-        if m(self.wire_protocol.parse_init_connect(line)):
-            return dict(next_handle=self.handle_http_connect(m.v, lg))
-        elif m(self.wire_protocol.parse_init_proxy(line)):
-            method, _, _, _, path, httpversion = m.v
-        elif m(self.wire_protocol.parse_init_http(line)):
-            method, path, httpversion = m.v
-        else:
-            s = "Invalid first line: %s" % repr(line)
-            lg(s)
-            return dict(errors=dict(type="error", msg=s))
-
-        headers = self.wire_protocol.read_headers()
-        if headers is None:
-            s = "Invalid headers"
-            lg(s)
-            return dict(errors=dict(type="error", msg=s))
-
-        try:
-            body = self.wire_protocol.read_http_body(
-                headers,
-                None,
-                method,
-                None,
-                True,
-            )
-        except http.HttpError as s:
-            s = str(s)
-            lg(s)
-            return dict(errors=dict(type="error", msg=s))
-
-        return dict(
-            method=method,
-            path=path,
-            headers=headers,
-            body=body,
-            httpversion=httpversion)
+    def read_request(self, lg=None):
+        return self.wire_protocol.read_request(allow_empty=True)

--- a/libpathod/protocols/http.py
+++ b/libpathod/protocols/http.py
@@ -41,7 +41,7 @@ class HTTPProtocol:
         """
             Handle a CONNECT request.
         """
-        self.wire_protocol.read_headers()
+
         self.pathod_handler.wfile.write(
             'HTTP/1.1 200 Connection established\r\n' +
             ('Proxy-agent: %s\r\n' % version.NAMEVERSION) +

--- a/libpathod/protocols/http.py
+++ b/libpathod/protocols/http.py
@@ -56,7 +56,7 @@ class HTTPProtocol:
                 self.pathod_handler.convert_to_ssl(
                     cert,
                     key,
-                    handle_sni=self.pathod_handler._handle_sni,
+                    handle_sni=self.pathod_handler.handle_sni,
                     request_client_cert=self.pathod_handler.server.ssloptions.request_client_cert,
                     cipher_list=self.pathod_handler.server.ssloptions.ciphers,
                     method=self.pathod_handler.server.ssloptions.ssl_version,

--- a/libpathod/protocols/http2.py
+++ b/libpathod/protocols/http2.py
@@ -12,7 +12,7 @@ class HTTP2Protocol:
     def make_error_response(self, reason, body):
         return language.http2.make_error_response(reason, body)
 
-    def read_request(self):
+    def read_request(self, lg=None):
         self.wire_protocol.perform_server_connection_preface()
         return self.wire_protocol.read_request()
 

--- a/libpathod/protocols/http2.py
+++ b/libpathod/protocols/http2.py
@@ -1,4 +1,4 @@
-from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from netlib.http import http2
 from .. import version, app, language, utils, log
 
 class HTTP2Protocol:

--- a/libpathod/protocols/http2.py
+++ b/libpathod/protocols/http2.py
@@ -1,0 +1,20 @@
+from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from .. import version, app, language, utils, log
+
+class HTTP2Protocol:
+
+    def __init__(self, pathod_handler):
+        self.pathod_handler = pathod_handler
+        self.wire_protocol = http2.HTTP2Protocol(
+            self.pathod_handler, is_server=True, dump_frames=self.pathod_handler.http2_framedump
+        )
+
+    def make_error_response(self, reason, body):
+        return language.http2.make_error_response(reason, body)
+
+    def read_request(self):
+        self.wire_protocol.perform_server_connection_preface()
+        return self.wire_protocol.read_request()
+
+    def create_response(self, code, stream_id, headers, body):
+        return self.wire_protocol.create_response(code, stream_id, headers, body)

--- a/libpathod/protocols/websockets.py
+++ b/libpathod/protocols/websockets.py
@@ -1,6 +1,6 @@
 import time
 
-from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from netlib import tcp, http, wsgi, certutils, websockets, odict
 from .. import version, app, language, utils, log
 
 class WebsocketsProtocol:

--- a/libpathod/protocols/websockets.py
+++ b/libpathod/protocols/websockets.py
@@ -1,0 +1,54 @@
+import time
+
+from netlib import tcp, http, http2, wsgi, certutils, websockets, odict
+from .. import version, app, language, utils, log
+
+class WebsocketsProtocol:
+
+    def __init__(self, pathod_handler):
+        self.pathod_handler = pathod_handler
+
+    def handle_websocket(self, logger):
+        while True:
+            with logger.ctx() as lg:
+                started = time.time()
+                try:
+                    frm = websockets.Frame.from_file(self.pathod_handler.rfile)
+                except tcp.NetLibIncomplete as e:
+                    lg("Error reading websocket frame: %s" % e)
+                    break
+                ended = time.time()
+                lg(frm.human_readable())
+            retlog = dict(
+                type="inbound",
+                protocol="websockets",
+                started=started,
+                duration=ended - started,
+                frame=dict(
+                ),
+                cipher=None,
+            )
+            if self.pathod_handler.ssl_established:
+                retlog["cipher"] = self.pathod_handler.get_current_cipher()
+            self.pathod_handler.addlog(retlog)
+            ld = language.websockets.NESTED_LEADER
+            if frm.payload.startswith(ld):
+                nest = frm.payload[len(ld):]
+                try:
+                    wf_gen = language.parse_websocket_frame(nest)
+                except language.exceptions.ParseException as v:
+                    logger.write(
+                        "Parse error in reflected frame specifcation:"
+                        " %s" % v.msg
+                    )
+                    return None, None
+                for frm in wf_gen:
+                    with logger.ctx() as lg:
+                        frame_log = language.serve(
+                            frm,
+                            self.pathod_handler.wfile,
+                            self.pathod_handler.settings
+                        )
+                        lg("crafting websocket spec: %s" % frame_log["spec"])
+                        self.pathod_handler.addlog(frame_log)
+        return self.handle_websocket, None

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -7,7 +7,7 @@ class TestApp(tutils.DaemonTests):
     def test_index(self):
         r = self.getpath("/")
         assert r.status_code == 200
-        assert r.content
+        assert r.body
 
     def test_about(self):
         r = self.getpath("/about")
@@ -38,48 +38,48 @@ class TestApp(tutils.DaemonTests):
     def test_response_preview(self):
         r = self.getpath("/response_preview", params=dict(spec="200"))
         assert r.status_code == 200
-        assert 'Response' in r.content
+        assert 'Response' in r.body
 
         r = self.getpath("/response_preview", params=dict(spec="foo"))
         assert r.status_code == 200
-        assert 'Error' in r.content
+        assert 'Error' in r.body
 
         r = self.getpath("/response_preview", params=dict(spec="200:b@100m"))
         assert r.status_code == 200
-        assert "too large" in r.content
+        assert "too large" in r.body
 
         r = self.getpath("/response_preview", params=dict(spec="200:b@5k"))
         assert r.status_code == 200
-        assert 'Response' in r.content
+        assert 'Response' in r.body
 
         r = self.getpath(
             "/response_preview",
             params=dict(
                 spec="200:b<nonexistent"))
         assert r.status_code == 200
-        assert 'File access denied' in r.content
+        assert 'File access denied' in r.body
 
         r = self.getpath("/response_preview", params=dict(spec="200:b<file"))
         assert r.status_code == 200
-        assert 'testfile' in r.content
+        assert 'testfile' in r.body
 
     def test_request_preview(self):
         r = self.getpath("/request_preview", params=dict(spec="get:/"))
         assert r.status_code == 200
-        assert 'Request' in r.content
+        assert 'Request' in r.body
 
         r = self.getpath("/request_preview", params=dict(spec="foo"))
         assert r.status_code == 200
-        assert 'Error' in r.content
+        assert 'Error' in r.body
 
         r = self.getpath("/request_preview", params=dict(spec="get:/:b@100m"))
         assert r.status_code == 200
-        assert "too large" in r.content
+        assert "too large" in r.body
 
         r = self.getpath("/request_preview", params=dict(spec="get:/:b@5k"))
         assert r.status_code == 200
-        assert 'Request' in r.content
+        assert 'Request' in r.body
 
         r = self.getpath("/request_preview", params=dict(spec=""))
         assert r.status_code == 200
-        assert 'empty spec' in r.content
+        assert 'empty spec' in r.body

--- a/test/test_language_http2.py
+++ b/test/test_language_http2.py
@@ -1,9 +1,11 @@
 import cStringIO
 
+import netlib
 from netlib import tcp
+from netlib.http import user_agents
+
 from libpathod import language
 from libpathod.language import http2, base
-import netlib
 import tutils
 
 
@@ -18,7 +20,7 @@ def parse_response(s):
 def default_settings():
     return language.Settings(
         request_host="foo.com",
-        protocol=netlib.http2.HTTP2Protocol(tcp.TCPClient(('localhost', 1234)))
+        protocol=netlib.http.http2.HTTP2Protocol(tcp.TCPClient(('localhost', 1234)))
     )
 
 
@@ -121,7 +123,7 @@ class TestRequest:
     def test_user_agent(self):
         r = parse_request('GET:/:r:ua')
         assert len(r.headers) == 1
-        assert r.headers[0].values(default_settings()) == ("user-agent", netlib.http_uastrings.get_by_shortcut('a')[2])
+        assert r.headers[0].values(default_settings()) == ("user-agent", user_agents.get_by_shortcut('a')[2])
 
     def test_render_with_headers(self):
         s = cStringIO.StringIO()

--- a/test/test_pathoc.py
+++ b/test/test_pathoc.py
@@ -4,13 +4,15 @@ import re
 import OpenSSL
 from mock import Mock
 
-from netlib import tcp, http, http2, http_semantics, socks
+from netlib import tcp, http, socks
+from netlib.http import http2
+
 from libpathod import pathoc, test, version, pathod, language
 import tutils
 
 
 def test_response():
-    r = http_semantics.Response("1.1", 200, "Message", {}, None, None)
+    r = http.Response("1.1", 200, "Message", {}, None, None)
     assert repr(r)
 
 

--- a/test/test_pathoc.py
+++ b/test/test_pathoc.py
@@ -4,13 +4,13 @@ import re
 import OpenSSL
 from mock import Mock
 
-from netlib import tcp, http, http2, socks
+from netlib import tcp, http, http2, http_semantics, socks
 from libpathod import pathoc, test, version, pathod, language
 import tutils
 
 
 def test_response():
-    r = pathoc.Response("1.1", 200, "Message", {}, None, None)
+    r = http_semantics.Response("1.1", 200, "Message", {}, None, None)
     assert repr(r)
 
 

--- a/test/test_pathoc.py
+++ b/test/test_pathoc.py
@@ -45,7 +45,7 @@ class _TestDaemon:
         )
         c.connect()
         resp = c.request("get:/api/info")
-        assert tuple(json.loads(resp.content)["version"]) == version.IVERSION
+        assert tuple(json.loads(resp.body)["version"]) == version.IVERSION
 
     def tval(
         self,
@@ -105,7 +105,7 @@ class TestDaemonSSL(_TestDaemon):
         c.connect()
         c.request("get:/p/200")
         r = c.request("get:/api/log")
-        d = json.loads(r.content)
+        d = json.loads(r.body)
         assert d["log"][0]["request"]["sni"] == "foobar.com"
 
     def test_showssl(self):
@@ -121,7 +121,7 @@ class TestDaemonSSL(_TestDaemon):
         c.connect()
         c.request("get:/p/200")
         r = c.request("get:/api/log")
-        d = json.loads(r.content)
+        d = json.loads(r.body)
         assert d["log"][0]["request"]["clientcert"]["keyinfo"]
 
     def test_http2_without_ssl(self):

--- a/test/test_pathoc.py
+++ b/test/test_pathoc.py
@@ -5,7 +5,7 @@ import OpenSSL
 from mock import Mock
 
 from netlib import tcp, http, socks
-from netlib.http import http2
+from netlib.http import http1, http2
 
 from libpathod import pathoc, test, version, pathod, language
 import tutils
@@ -272,8 +272,7 @@ class TestDaemonHTTP2(_TestDaemon):
             c = pathoc.Pathoc(
                 ("127.0.0.1", self.d.port),
             )
-            # TODO: change if other protocols get implemented
-            assert c.protocol is None
+            assert isinstance(c.protocol, http1.HTTP1Protocol)
 
         def test_http2_alpn(self):
             c = pathoc.Pathoc(

--- a/test/test_pathod.py
+++ b/test/test_pathod.py
@@ -3,7 +3,7 @@ import cStringIO
 import OpenSSL
 
 from libpathod import pathod, version
-from netlib import tcp, http, http2
+from netlib import tcp, http
 import tutils
 
 

--- a/test/test_pathod.py
+++ b/test/test_pathod.py
@@ -51,7 +51,7 @@ class TestNoApi(tutils.DaemonTests):
         assert self.getpath("/log").status_code == 404
         r = self.getpath("/")
         assert r.status_code == 200
-        assert not "Log" in r.content
+        assert not "Log" in r.body
 
 
 class TestNotAfterConnect(tutils.DaemonTests):
@@ -119,7 +119,7 @@ class TestNocraft(tutils.DaemonTests):
     def test_nocraft(self):
         r = self.get(r"200:b'\xf0'")
         assert r.status_code == 800
-        assert "Crafting disabled" in r.content
+        assert "Crafting disabled" in r.body
 
 
 class CommonTests(tutils.DaemonTests):
@@ -152,7 +152,7 @@ class CommonTests(tutils.DaemonTests):
 
     def test_disconnect(self):
         rsp = self.get("202:b@100k:d200")
-        assert len(rsp.content) < 200
+        assert len(rsp.body) < 200
 
     def test_parserr(self):
         rsp = self.get("400:msg,b:")
@@ -161,7 +161,7 @@ class CommonTests(tutils.DaemonTests):
     def test_static(self):
         rsp = self.get("200:b<file")
         assert rsp.status_code == 200
-        assert rsp.content.strip() == "testfile"
+        assert rsp.body.strip() == "testfile"
 
     def test_anchor(self):
         rsp = self.getpath("anchor/foo")
@@ -201,7 +201,7 @@ class CommonTests(tutils.DaemonTests):
     def test_source_access_denied(self):
         rsp = self.get("200:b</foo")
         assert rsp.status_code == 800
-        assert "File access denied" in rsp.content
+        assert "File access denied" in rsp.body
 
     def test_proxy(self):
         r, _ = self.pathoc([r"get:'http://foo.com/p/202':da"])

--- a/test/test_pathod.py
+++ b/test/test_pathod.py
@@ -284,5 +284,4 @@ class TestHTTP2(tutils.DaemonTests):
 
         def test_http2(self):
             r, _ = self.pathoc(["GET:/"], ssl=True, use_http2=True)
-            print(r)
             assert r[0].status_code == "800"

--- a/test/tutils.py
+++ b/test/tutils.py
@@ -62,7 +62,7 @@ class DaemonTests(object):
 
     def getpath(self, path, params=None):
         scheme = "https" if self.ssl else "http"
-        return requests.get(
+        resp = requests.get(
             "%s://localhost:%s/%s" % (
                 scheme,
                 self.d.port,
@@ -71,9 +71,13 @@ class DaemonTests(object):
             verify=False,
             params=params
         )
+        resp.body = resp.content
+        return resp
 
     def get(self, spec):
-        return requests.get(self.d.p(spec), verify=False)
+        resp = requests.get(self.d.p(spec), verify=False)
+        resp.body = resp.content
+        return resp
 
     def pathoc(
         self,


### PR DESCRIPTION
This PR starts of a larger refactoring process to unify everything related to HTTP semantics and split the actual "on-the-wire" protocol from the overall flow behind it.

Mostly moving code around between projects, modules, and classes.

This PR requires https://github.com/mitmproxy/netlib/pull/81 to work properly.