### PR TITLE
[WIP] Protocol Refactoring for HTTP/2

### DIFF
--- a/libpathod/language/http.py
+++ b/libpathod/language/http.py
@@ -7,6 +7,9 @@ import netlib.websockets
 from netlib.http import status_codes, user_agents
 from . import base, exceptions, actions, message
 
+# TODO: use netlib.semantics.protocol assemble method,
+# instead of duplicating the HTTP on-the-wire representation here.
+# see http2 language for an example
 
 class WS(base.CaselessLiteral):
     TOK = "ws"

--- a/libpathod/protocols/http2.py
+++ b/libpathod/protocols/http2.py
@@ -16,5 +16,5 @@ class HTTP2Protocol:
         self.wire_protocol.perform_server_connection_preface()
         return self.wire_protocol.read_request()
 
-    def create_response(self, code, stream_id, headers, body):
-        return self.wire_protocol.create_response(code, stream_id, headers, body)
+    def assemble(self, message):
+        return self.wire_protocol.assemble(message)

--- a/test/test_pathoc.py
+++ b/test/test_pathoc.py
@@ -301,4 +301,4 @@ class TestDaemonHTTP2(_TestDaemon):
             )
             c.connect()
             resp = c.request("get:/p/200")
-            assert resp.status_code == "200"
+            assert resp.status_code == 200

--- a/test/test_pathod.py
+++ b/test/test_pathod.py
@@ -284,4 +284,4 @@ class TestHTTP2(tutils.DaemonTests):
 
         def test_http2(self):
             r, _ = self.pathoc(["GET:/"], ssl=True, use_http2=True)
-            assert r[0].status_code == "800"
+            assert r[0].status_code == 800


### PR DESCRIPTION
This PR changes the protocol architecture and adds a unified interface for HTTP/1 and HTTP/2.

requires https://github.com/mitmproxy/netlib/pull/84
(tests will fail without it)